### PR TITLE
Update PaperMC 1.12.2 and Fix PaperMC 1.14.4

### DIFF
--- a/minecraft/paperspigot/paperspigot-1.12.2.jar.conf
+++ b/minecraft/paperspigot/paperspigot-1.12.2.jar.conf
@@ -6,7 +6,7 @@
 
 [config]
 name = [PaperSpigot] 1.12.2
-source = http://ci.destroystokyo.com/job/PaperSpigot/1266/artifact/paperclip-1266.jar
+source = https://papermc.io/ci/job/Paper/1618/artifact/paperclip-1618.jar
 configSource = http://raw.githubusercontent.com/ValentinTh/MultiCraft-JAR-Conf/master/minecraft/paperspigot/paperspigot-1.12.2.jar.conf
 
 [encoding]

--- a/minecraft/paperspigot/paperspigot-1.12.2.jar.conf
+++ b/minecraft/paperspigot/paperspigot-1.12.2.jar.conf
@@ -1,7 +1,7 @@
 ## ===========================================================
 ##       MULTICRAFT CONFIGURATION TO ADD .JAR TYPES
 ##  To simplify all the add of JAR in less time than ever.
-##  This configuration was edited by Valentin.T - 29/12/2017.
+##  This configuration was edited by Valentin.T - 24/12/2019.
 ## ===========================================================
 
 [config]

--- a/minecraft/paperspigot/paperspigot-1.14.4.jar.conf
+++ b/minecraft/paperspigot/paperspigot-1.14.4.jar.conf
@@ -1,7 +1,7 @@
 ## ===========================================================
 ##       MULTICRAFT CONFIGURATION TO ADD .JAR TYPES
 ##  To simplify all the add of JAR in less time than ever.
-##  This configuration was edited by Valentin.T - 13/12/2019.
+##  This configuration was edited by Valentin.T - 24/12/2019.
 ## ===========================================================
 
 [config]

--- a/minecraft/paperspigot/paperspigot-1.14.4.jar.conf
+++ b/minecraft/paperspigot/paperspigot-1.14.4.jar.conf
@@ -6,7 +6,7 @@
 
 [config]
 name = [PaperSpigot] 1.14.4
-source = https://papermc.io/ci/job/Paper-1.14/lastSuccessfulBuild/artifact/paperclip-236.jar
+source = https://papermc.io/ci/job/Paper-1.14/237/artifact/paperclip-237.jar
 configSource = http://raw.githubusercontent.com/ValentinTh/MultiCraft-JAR-Conf/master/minecraft/paperspigot/paperspigot-1.14.4.jar.conf
 
 [encoding]


### PR DESCRIPTION
Updates PaperMC 1.12.2 to use what I believe is the final build of paper 1.12 and use the new URL for Paper's CI.
Fixed PaperMC 1.14.4 to use the latest build of Paper while also not using LastSuccessfulArtifact so that future downloads are not corrupted whenever Paper updates. 