### PR TITLE
Add Paper 1.13.2 and Paper 1.15.1

### DIFF
--- a/minecraft/paperspigot/paperspigot-1.12.2.jar.conf
+++ b/minecraft/paperspigot/paperspigot-1.12.2.jar.conf
@@ -5,11 +5,7 @@
 ## ===========================================================
 
 [config]
-<<<<<<< HEAD
 name = [PaperSpigot] 1.12.2 (Build: 1618)
-=======
-name = [PaperSpigot] 1.12.2
->>>>>>> upstream/master
 source = https://papermc.io/ci/job/Paper/1618/artifact/paperclip-1618.jar
 configSource = http://raw.githubusercontent.com/ValentinTh/MultiCraft-JAR-Conf/master/minecraft/paperspigot/paperspigot-1.12.2.jar.conf
 

--- a/minecraft/paperspigot/paperspigot-1.13.2.jar.conf
+++ b/minecraft/paperspigot/paperspigot-1.13.2.jar.conf
@@ -5,13 +5,9 @@
 ## ===========================================================
 
 [config]
-<<<<<<< HEAD
-name = [PaperSpigot] 1.12.2 (Build: 1618)
-=======
-name = [PaperSpigot] 1.12.2
->>>>>>> upstream/master
-source = https://papermc.io/ci/job/Paper/1618/artifact/paperclip-1618.jar
-configSource = http://raw.githubusercontent.com/ValentinTh/MultiCraft-JAR-Conf/master/minecraft/paperspigot/paperspigot-1.12.2.jar.conf
+name = [PaperSpigot] 1.13.2 (Build: 653)
+source = https://papermc.io/ci/job/Paper-1.13/653/artifact/paperclip-653.jar
+configSource = http://raw.githubusercontent.com/ValentinTh/MultiCraft-JAR-Conf/master/minecraft/paperspigot/paperspigot-1.13.2.jar.conf
 
 [encoding]
 encode = utf-8

--- a/minecraft/paperspigot/paperspigot-1.14.4.jar.conf
+++ b/minecraft/paperspigot/paperspigot-1.14.4.jar.conf
@@ -5,11 +5,7 @@
 ## ===========================================================
 
 [config]
-<<<<<<< HEAD
 name = [PaperSpigot] 1.14.4 (Build: 237)
-=======
-name = [PaperSpigot] 1.14.4
->>>>>>> upstream/master
 source = https://papermc.io/ci/job/Paper-1.14/237/artifact/paperclip-237.jar
 configSource = http://raw.githubusercontent.com/ValentinTh/MultiCraft-JAR-Conf/master/minecraft/paperspigot/paperspigot-1.14.4.jar.conf
 

--- a/minecraft/paperspigot/paperspigot-1.14.4.jar.conf
+++ b/minecraft/paperspigot/paperspigot-1.14.4.jar.conf
@@ -5,7 +5,11 @@
 ## ===========================================================
 
 [config]
+<<<<<<< HEAD
+name = [PaperSpigot] 1.14.4 (Build: 237)
+=======
 name = [PaperSpigot] 1.14.4
+>>>>>>> upstream/master
 source = https://papermc.io/ci/job/Paper-1.14/237/artifact/paperclip-237.jar
 configSource = http://raw.githubusercontent.com/ValentinTh/MultiCraft-JAR-Conf/master/minecraft/paperspigot/paperspigot-1.14.4.jar.conf
 

--- a/minecraft/paperspigot/paperspigot-1.15.1.jar.conf
+++ b/minecraft/paperspigot/paperspigot-1.15.1.jar.conf
@@ -1,17 +1,13 @@
 ## ===========================================================
 ##       MULTICRAFT CONFIGURATION TO ADD .JAR TYPES
 ##  To simplify all the add of JAR in less time than ever.
-##  This configuration was edited by Valentin.T - 24/12/2019.
+##  This configuration was edited by Kevinsal03 - 24/12/2019.
 ## ===========================================================
 
 [config]
-<<<<<<< HEAD
-name = [PaperSpigot] 1.12.2 (Build: 1618)
-=======
-name = [PaperSpigot] 1.12.2
->>>>>>> upstream/master
-source = https://papermc.io/ci/job/Paper/1618/artifact/paperclip-1618.jar
-configSource = http://raw.githubusercontent.com/ValentinTh/MultiCraft-JAR-Conf/master/minecraft/paperspigot/paperspigot-1.12.2.jar.conf
+name = [PaperSpigot] 1.15.1 (Build: 29)
+source = https://papermc.io/ci/job/Paper-1.15/29/artifact/paperclip-29.jar
+configSource = http://raw.githubusercontent.com/ValentinTh/MultiCraft-JAR-Conf/master/minecraft/paperspigot/paperspigot-1.15.1.jar.conf
 
 [encoding]
 encode = utf-8


### PR DESCRIPTION
Adds support for Paper 1.13.2 and Paper 1.15.1, locked at specific builds.

Added the build number that each Paper version is at since it has to be manually updated.